### PR TITLE
fix(chungthuang): Run npm install or yarn install before running the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 First, run the development server:
 
 ```bash
+npm install
 npm run dev
 # or
+yarn install
 yarn dev
 ```
 


### PR DESCRIPTION
I got the following error when I first cloned the project
```
> site-projects@0.1.0 dev
> next dev

sh: next: command not found
```