### PR TITLE
Revert "ops(chungthuang): Schedule pod back on normal node"

### DIFF
--- a/production/kustomization.yaml
+++ b/production/kustomization.yaml
@@ -7,3 +7,31 @@ images:
 - name: devlaunchers/site-projects
   newName: devlaunchers/site-projects
   newTag: 1.1.4 # {"$imagepolicy": "site-projects:site-projects:tag"}
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    namespace: site-projects
+    name: site-projects
+    labels:
+      app: site-projects
+  spec:
+    template:
+      spec:
+        containers:
+        - name: site-projects
+          resources:
+            limits:
+              cpu: 0.05
+              memory: 200Mi
+            requests:
+              cpu: 0.05
+              memory: 200Mi
+        nodeSelector:
+          type: virtual-kubelet
+        tolerations:
+        - key: virtual-kubelet.io/provider
+          operator: Exists
+        - key: azure.com/aci
+          effect: NoSchedule


### PR DESCRIPTION
This reverts commit dfacd186c05bb90827b34b9eb55a162cbe8ed3f1.
I thought the node has 4 GB to allocate, but turns out only 2 out of 4 is allocatable. 